### PR TITLE
Add deck and deck_card_block models, with appropriate migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem "bootsnap", require: false
 
 gem "rexml"
 
+gem "pluck_to_hash"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,9 @@ GEM
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     pg (1.4.2)
+    pluck_to_hash (1.0.2)
+      activerecord (>= 4.0.2)
+      activesupport (>= 4.0.2)
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
@@ -199,6 +202,7 @@ DEPENDENCIES
   jsbundling-rails
   jwt
   pg (~> 1.1)
+  pluck_to_hash
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)
   rexml

--- a/app/models/card_block.rb
+++ b/app/models/card_block.rb
@@ -1,4 +1,7 @@
 class CardBlock < ApplicationRecord
   belongs_to :card_set
   has_many :cards
+
+  has_many :deck_card_blocks
+  has_many :decks, through: :deck_card_blocks
 end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -1,0 +1,17 @@
+class Deck < ApplicationRecord
+  belongs_to :user
+
+  has_many :deck_card_blocks
+  has_many :card_blocks, through: :deck_card_blocks
+  has_many :cards, through: :card_blocks
+
+  def card_blocks_as_hash_with_quantity
+    card_block_attributes = CardBlock.attribute_names - ["created_at", "updated_at"]
+
+    self.card_blocks.pluck_to_hash(*card_block_attributes, "deck_card_blocks.quantity as quantity")
+  end
+
+  def destroy_all_card_blocks
+    self.deck_card_blocks.destroy_all
+  end
+end

--- a/app/models/deck_card_block.rb
+++ b/app/models/deck_card_block.rb
@@ -1,0 +1,4 @@
+class DeckCardBlock < ApplicationRecord
+  belongs_to :card_block
+  belongs_to :deck
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
 
   has_secure_password
 
+  has_many :decks
+
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true
   validates :username, presence: true, uniqueness: true

--- a/db/migrate/20231201150403_create_decks.rb
+++ b/db/migrate/20231201150403_create_decks.rb
@@ -1,0 +1,19 @@
+class CreateDecks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :decks do |t|
+      t.string :name
+      t.string :description
+
+      t.belongs_to :user
+
+      t.timestamps
+    end
+
+    create_table :deck_card_blocks do |t|
+      t.belongs_to :card_block
+      t.belongs_to :deck
+
+      t.integer :quantity
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_25_163241) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_01_150403) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_25_163241) do
     t.datetime "updated_at", null: false
     t.index ["card_block_id"], name: "index_cards_on_card_block_id"
     t.index ["name"], name: "index_cards_on_name"
+  end
+
+  create_table "deck_card_blocks", force: :cascade do |t|
+    t.bigint "card_block_id"
+    t.bigint "deck_id"
+    t.integer "quantity"
+    t.index ["card_block_id"], name: "index_deck_card_blocks_on_card_block_id"
+    t.index ["deck_id"], name: "index_deck_card_blocks_on_deck_id"
+  end
+
+  create_table "decks", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_decks_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Tested this in the rails console with a variety of operations.

To update a deck, we're going to expect a payload of something like this:

```
[{:card_block_id=>3, :deck_id=>1, :quantity=>1}, {:card_block_id=>2, :deck_id=>1, :quantity=>2}, {:card_block_id=>1, :deck_id=>1, :quantity=>1}]
```

(Well, json that can convert to this, obviously)

and then call `deck.destroy_all_card_blocks` before applying a bulk-update via `insert_all`.  This will require us to do any validations at the DB level, since `insert_all` skips AR validations.

Not sure this is really "best" but in my testing, it's certainly fast.   One optimization we can look at making is getting Rails to destroy in a single statement (destroy_all appears to do it one at a time, albeit in one transaction).