### PR TITLE
Add affiliation model, update deck creation to include it

### DIFF
--- a/app/controllers/api/decks_controller.rb
+++ b/app/controllers/api/decks_controller.rb
@@ -13,15 +13,21 @@ class Api::DecksController < ApplicationController
   # Shape of body should be:
   # {
   #   "name": "Some Deck Name",  (required)
+  #   "affiliation_id": 12,  (the id of the affiliation used for this deck - required)
   #   "description": "Some Deck Description, should support some basic markup",  (optional)
   # }
   # We are not going to allow assigning card blocks as part of initialization
   # So our flows must account for this
 
   def create
-    permitted_params = params.permit(:name, :description)
+    permitted_params = params.permit(:name, :description, :affiliation_id)
 
-    deck = Deck.create!(name: permitted_params[:name], description: permitted_params[:description], user: @current_user)
+    deck = Deck.create!(
+      name: permitted_params[:name],
+      description: permitted_params[:description],
+      affiliation_id: permitted_params[:affiliation_id],
+      user: @current_user
+    )
 
     respond_to do |format|
       format.json { render json: deck.as_json }

--- a/app/models/affiliation.rb
+++ b/app/models/affiliation.rb
@@ -1,0 +1,3 @@
+class Affiliation < ApplicationRecord
+  has_many :decks
+end

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -1,5 +1,6 @@
 class Deck < ApplicationRecord
   belongs_to :user
+  belongs_to :affiliation
 
   has_many :deck_card_blocks
   has_many :card_blocks, through: :deck_card_blocks
@@ -17,6 +18,9 @@ class Deck < ApplicationRecord
       description: description,
       card_blocks: card_blocks_as_hashes_with_quantity,
       cards: cards_as_hashes_with_quantity,
+      affiliation: affiliation.as_json.except("created_at", "updated_at"),
+      created_at: created_at,
+      updated_at: updated_at,
     }
   end
 

--- a/db/migrate/20240229014914_add_affiliations.rb
+++ b/db/migrate/20240229014914_add_affiliations.rb
@@ -1,0 +1,19 @@
+class AddAffiliations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :affiliations do |t|
+      t.string :name
+      t.integer :resources
+      t.string :text
+      t.string :side
+      t.string :affiliation_name
+
+      t.timestamps
+    end
+
+    change_table :decks do |t|
+      t.integer :affiliation_id
+    end
+
+    add_foreign_key :decks, :affiliations
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_01_150403) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_29_014914) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "affiliations", force: :cascade do |t|
+    t.string "name"
+    t.integer "resources"
+    t.string "text"
+    t.string "side"
+    t.string "affiliation_name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "card_blocks", force: :cascade do |t|
     t.bigint "card_set_id"
@@ -71,6 +81,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_01_150403) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "affiliation_id"
     t.index ["user_id"], name: "index_decks_on_user_id"
   end
 
@@ -85,4 +96,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_01_150403) do
 
   add_foreign_key "card_blocks", "card_sets"
   add_foreign_key "cards", "card_blocks"
+  add_foreign_key "decks", "affiliations"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,6 +51,17 @@ files_to_process.each do |file|
     Card.create(cards_to_create) 
   end
 
+  # Handle affiliation cards, which don't belong to a set, and were left out above
+  affiliation_cards = raw_card_attrs
+                        .select { |c| c["card_type"] == "Affiliation" }
+                        .map { |c| c.slice("affiliation", "resources", "name", "side", "text") }
+                        .map do |c|
+                          c["affiliation_name"] = c.delete("affiliation")
+                          c
+                        end
+
+  Affiliation.create(affiliation_cards) if affiliation_cards.any?
+
   # This labels the custom sets clearly
   ffg_sets = CardBlock.all.map(&:card_set).uniq
   custom_sets = CardSet.all - ffg_sets


### PR DESCRIPTION
I realized when I went to go do the UI for deck creation that I wanted an affiliation model.  So this changeset creates one.

I also used this to tweak the response of the deck json to include timestamps so we could sort on them (or do whatever with them).