### PR TITLE
Fix password resets on production

### DIFF
--- a/app/mailers/password_mailer.rb
+++ b/app/mailers/password_mailer.rb
@@ -9,7 +9,7 @@ class PasswordMailer < ApplicationMailer
     @user = params[:user]
     @token = @user.signed_id(purpose: 'password_reset', expires_in: 10.minutes)
 
-    @password_reset_url = "http://localhost:3000/resetPassword/#{@token}"
+    @password_reset_url = Rails.env == 'production' ? "https://swlcgdb.com/resetPassword/#{@token}" : "http://localhost:3000/resetPassword/#{@token}"
 
     mail to: @user.email
   end

--- a/app/views/password_mailer/reset.html.erb
+++ b/app/views/password_mailer/reset.html.erb
@@ -1,4 +1,4 @@
-Hi <%= @user.name %>
+Hi <%= @user.username %>
 <br>
 Someone requested a reset of your password on swlcgdb.com.
 <br>

--- a/app/views/password_mailer/reset.text.erb
+++ b/app/views/password_mailer/reset.text.erb
@@ -1,4 +1,4 @@
-Hi <%= @user.name %>
+Hi <%= @user.username %>
 Someone requested a reset of your password on swlcgdb.com.
 If this was you, click on the link to reset your password. The link will expirte automatically in 10 minutes.
 <%= @password_reset_url %>


### PR DESCRIPTION
The password reset mailer was blowing up with `ActionView::Template::Error (undefined method 'name'...` - clearly related to the recent migration away from `name` in favor of `username`.

I also made sure the `@password_reset_url` was correct based on the env.