### PR TITLE
Add tooltips to assist with search, add block numbers to objectives

### DIFF
--- a/app/javascript/components/DeckBuilder.jsx
+++ b/app/javascript/components/DeckBuilder.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Tooltip } from "react-tooltip";
 
 import CardPanel from "./CardPanel";
+import SearchTooltipContent from "./SearchTooltipContent";
 import getIconsFromIconString from "../util/getIconsFromIconString";
 
 const DeckBuilder = ({
@@ -57,6 +58,14 @@ const DeckBuilder = ({
       <div className="input-group">
         <input className="form-control flex-fill" onChange={ handleInputChange } type="search" placeholder="Search" aria-label="Search" />
         <button className="btn btn-outline-success" onClick={ handleSearchSubmit }>Search</button>
+        <div className="d-flex justify-content-center align-items-center">
+          <a
+            className="px-2"
+            data-tooltip-id="search-tooltip"
+          >
+            Help
+          </a>
+        </div>
       </div>
       {/* EXTRACT THIS - SHARED WITH CardList */}
       <div className="container">
@@ -111,6 +120,15 @@ const DeckBuilder = ({
           style={{ backgroundColor: "white", color: "black", boxShadow: "0px 0px 4px grey", maxWidth: "400px" }}
           render={({ content }) => <CardPanel cardData={ JSON.parse(content) } />}
         />
+
+        { /* The zIndex style is a hack to get around the search button's z-index */ }
+        <Tooltip
+          id="search-tooltip"
+          place="left"
+          style={{ zIndex: "100" }}
+        >
+          <SearchTooltipContent assumeFilterButtons />
+        </Tooltip>
       </div>
     </>
   )

--- a/app/javascript/components/DeckCardList.jsx
+++ b/app/javascript/components/DeckCardList.jsx
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 import CardPanel from "../components/CardPanel";
 import affiliationCardNameToImageSrc from "../util/affiliationCardNameToImageSrc";
 
-const DeckCardListCardRow = ({ card }) =>
+const DeckCardListCardRow = ({ card, includeBlockNumber }) =>
   <div className="row">
     <div>
       { `${card.quantity}x ` }
@@ -18,6 +18,7 @@ const DeckCardListCardRow = ({ card }) =>
       >
         {card.name}
       </Link>
+      { includeBlockNumber && ` (${card.block})`}
     </div>
   </div>;
 
@@ -39,7 +40,7 @@ const DeckCardList = ({ deckData }) => {
           <div className="container p-2">
             <p className="fw-bold">Objectives</p>
             {
-              objectiveCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card}/>)
+              objectiveCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card} includeBlockNumber />)
             }
           </div>
         </div>

--- a/app/javascript/components/SearchTooltipContent.jsx
+++ b/app/javascript/components/SearchTooltipContent.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+const SearchTooltipContent = ({ assumeFilterButtons }) =>
+  <div>
+    <p className="lh-sm">You can use codes to filter your search</p>
+    <div className="lh-sm">For example, an input of</div>
+    <div className="lh-sm">&nbsp;&nbsp;c:2,f:1,x:jedi,Luke</div>
+    <div className="lh-sm">should translate to:</div>
+    <div className="lh-sm">&nbsp;&nbsp;cost: 2, force pip's: 1, text contains "jedi", name contains "Luke"</div>
+    <p className="lh-sm"></p>
+    <div className="lh-sm">Supported options:</div>
+    <div className="lh-sm">&nbsp;&nbsp;a:affiliation</div>
+    <div className="lh-sm">&nbsp;&nbsp;b:blast_damage</div>
+    <div className="lh-sm">&nbsp;&nbsp;c:cost</div>
+    <div className="lh-sm">&nbsp;&nbsp;f:force</div>
+    <div className="lh-sm">&nbsp;&nbsp;h:damage_capacity (health)</div>
+    <div className="lh-sm">&nbsp;&nbsp;k:traits</div>
+    <div className="lh-sm">&nbsp;&nbsp;o:tactics</div>
+    <div className="lh-sm">&nbsp;&nbsp;r:resources</div>
+    <div className="lh-sm">&nbsp;&nbsp;s:side</div>
+    <div className="lh-sm">&nbsp;&nbsp;t:type</div>
+    <div className="lh-sm">&nbsp;&nbsp;u:unit_damage</div>
+    <div className="lh-sm">&nbsp;&nbsp;x:text</div>
+    <p className="lh-sm"></p>
+    { assumeFilterButtons && <div className="lh-sm">This is in addition to whatever filters you've selected above.</div> }
+  </div>;
+
+export default SearchTooltipContent;

--- a/app/javascript/components/TopNavigation.jsx
+++ b/app/javascript/components/TopNavigation.jsx
@@ -1,7 +1,10 @@
 import React, { useContext, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { Tooltip } from "react-tooltip";
 
 import { AuthContext } from "./AuthProvider";
+import SearchTooltipContent from "./SearchTooltipContent";
+
 
 const TopNavigation = () => {
   const [searchString, setSearchString] = useState("")
@@ -38,6 +41,14 @@ const TopNavigation = () => {
             </li>
           </ul>
           <form className="d-flex" role="search">
+            <div className="d-flex justify-content-center align-items-center">
+              <a
+                className="px-2"
+                data-tooltip-id="top-nav-search-tooltip"
+              >
+                Help
+              </a>
+            </div>
             <input className="form-control me-2 normal-font" onChange={ handleInputChange } type="search" placeholder="Search" aria-label="Search" />
             <Link to={`search/${searchString}`}>
               <button className="btn btn-outline-success" type="submit">Search</button>
@@ -66,6 +77,13 @@ const TopNavigation = () => {
           </div>
         </div>
       </div>
+      <Tooltip
+        id="top-nav-search-tooltip"
+        place="bottom"
+        style={{ zIndex: "100" }}
+      >
+        <SearchTooltipContent />
+      </Tooltip>
     </nav>
   )
 }

--- a/app/services/card_search.rb
+++ b/app/services/card_search.rb
@@ -1,9 +1,20 @@
 # This service provides a way to search the DB for a card given a search string
+
+# E.g - A string of c:2,f:1,x:jedi,Luke should translate to:
+# "select * from cards where cost = 2 and force = 1 and text ILIKE %jedi% and name ILIKE %Luke%"
+
 # Supported options:
-#  c:cost
 #  a:affiliation
+#  b:blast_damage
+#  c:cost
+#  f:force
+#  h:damage_capacity (health)
 #  k:traits
+#  o:tactics
+#  r:resources
+#  s:side
 #  t:type
+#  u:unit_damage
 #  x:text
 
 # The default option (no option) should search the card name
@@ -38,20 +49,28 @@ class CardSearch
     sanitized_value = Card.sanitize_search_input(value) if value
 
     case flag
-    when 'c'
-      ["cost = ?", sanitized_value]
     when 'a'
       ["affiliation ILIKE ?", "%#{sanitized_value}%"]
+    when 'b'
+      ["combat_icons ILIKE ?", "%BD:#{sanitized_value}%"]
+    when 'c'
+      ["cost = ?", sanitized_value]
     when 'f'
-      ["cost = ?", sanitized_value]
+      ["force = ?", sanitized_value]
     when 'h'
-      ["cost = ?", sanitized_value]
+      ["damage_capacity = ?", sanitized_value]
     when 'k'
       ["traits ILIKE ?", "%#{sanitized_value}%"]
+    when 'o'
+      ["combat_icons ILIKE ?", "%T:#{sanitized_value}%"]
+    when 'r'
+      ["resources = ?", sanitized_value]
     when 's'
       ["side ILIKE ?", "%#{sanitized_value}%"]
     when 't'
       ["card_type ILIKE ?", "%#{sanitized_value}%"]
+    when 'u'
+      ["combat_icons ILIKE ?", "%UD:#{sanitized_value}%"]
     when 'x'
       ["text ILIKE ?", "%#{sanitized_value}%"]
     else


### PR DESCRIPTION
This adds a couple of tooltips around search to help teach folks how the search semantic works.

It also adds the block number to the deck display, which I think will provide a subtle, but helpful assist when you actually go to build the (physical) deck - especially if one's cards are organized by block number!