### PR TITLE
Bring add/remove buttons to objective area on edit deck view

### DIFF
--- a/app/javascript/components/DeckBuilder.jsx
+++ b/app/javascript/components/DeckBuilder.jsx
@@ -2,10 +2,12 @@ import React from "react";
 import { Tooltip } from "react-tooltip";
 
 import CardPanel from "./CardPanel";
+import QuantityUpdateButtonGroup from "./QuantityUpdateButtonGroup";
 import SearchTooltipContent from "./SearchTooltipContent";
 import getIconsFromIconString from "../util/getIconsFromIconString";
 
 const DeckBuilder = ({
+  cardBlockIdToQuantity,
   cardList,
   getStylesFor,
 
@@ -88,9 +90,11 @@ const DeckBuilder = ({
               cardList.map((card) =>
                 <tr key={`card-${card.id}`}>
                   <td>
-                    <button onClick={() => handleUpdateToQuantity(card.card_block_id, 0)} style={{ fontSize: "small" }}>0</button>
-                    <button onClick={() => handleUpdateToQuantity(card.card_block_id, 1)} style={{ fontSize: "small" }}>1</button>
-                    <button onClick={() => handleUpdateToQuantity(card.card_block_id, 2)} style={{ fontSize: "small" }}>2</button>
+                    <QuantityUpdateButtonGroup
+                      card={card}
+                      cardBlockIdToQuantity={cardBlockIdToQuantity}
+                      handleUpdateToQuantity={handleUpdateToQuantity}
+                    />
                   </td>
                   <td>
                     <div

--- a/app/javascript/components/DeckCardList.jsx
+++ b/app/javascript/components/DeckCardList.jsx
@@ -4,12 +4,22 @@ import { Tooltip } from "react-tooltip";
 import { Link } from "react-router-dom";
 
 import CardPanel from "../components/CardPanel";
+import QuantityUpdateButtonGroup from "../components/QuantityUpdateButtonGroup";
 import affiliationCardNameToImageSrc from "../util/affiliationCardNameToImageSrc";
 
-const DeckCardListCardRow = ({ card, includeBlockNumber }) =>
+const DeckCardListCardRow = ({ card, cardBlockIdToQuantity, handleUpdateToQuantity, includeBlockNumber }) =>
   <div className="row">
-    <div>
-      { `${card.quantity}x ` }
+    <div className="d-flex">
+      { 
+        (cardBlockIdToQuantity && handleUpdateToQuantity)
+        ? <QuantityUpdateButtonGroup
+            card={card}
+            cardBlockIdToQuantity={cardBlockIdToQuantity}
+            handleUpdateToQuantity={handleUpdateToQuantity}
+          />
+        : <div>{`${card.quantity}x`}&nbsp;</div>
+      }
+      
       <Link
         className="link-primary"
         data-tooltip-id="card-tooltip"
@@ -18,11 +28,11 @@ const DeckCardListCardRow = ({ card, includeBlockNumber }) =>
       >
         {card.name}
       </Link>
-      { includeBlockNumber && ` (${card.block})`}
+      { includeBlockNumber && <div>&nbsp;{`(${card.block})`}</div> }
     </div>
   </div>;
 
-const DeckCardList = ({ deckData }) => {
+const DeckCardList = ({ cardBlockIdToQuantity, handleUpdateToQuantity, deckData }) => {
   const deckCards = deckData?.cards || []
 
   const affiliationCardName = deckData?.affiliation?.name;
@@ -36,15 +46,22 @@ const DeckCardList = ({ deckData }) => {
   return (
     <div className="container">
       <div className="row">
-        <div className="col-md-6">
+        <div className="col-md-8">
           <div className="container p-2">
             <p className="fw-bold">Objectives</p>
             {
-              objectiveCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card} includeBlockNumber />)
+              objectiveCards.map((card) =>
+                <DeckCardListCardRow
+                  cardBlockIdToQuantity={cardBlockIdToQuantity}
+                  handleUpdateToQuantity={handleUpdateToQuantity}
+                  key={`dclcr-${card.id}`}
+                  card={card}
+                  includeBlockNumber
+                />)
             }
           </div>
         </div>
-        <div className="col-md-6">
+        <div className="col-md-4">
           <div className="container p-2">
             <img src={affiliationCardNameToImageSrc(affiliationCardName)} style={{ height: "200px" }}/>
           </div>

--- a/app/javascript/components/QuantityUpdateButtonGroup.jsx
+++ b/app/javascript/components/QuantityUpdateButtonGroup.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+const QuantityUpdateButtonGroup = ({ card, cardBlockIdToQuantity, handleUpdateToQuantity }) =>
+  <div className="me-1">
+    <button
+      onClick={() => handleUpdateToQuantity(card.card_block_id, 0)}
+      style={{
+        backgroundColor: `${(!cardBlockIdToQuantity[card.card_block_id] || cardBlockIdToQuantity[card.card_block_id] === 0) ? "darkgrey" : "inherit"}`,
+        fontSize: "small"
+      }}
+    >
+      0
+    </button>
+    <button
+      onClick={() => handleUpdateToQuantity(card.card_block_id, 1)}
+      style={{
+        backgroundColor: `${cardBlockIdToQuantity[card.card_block_id] === 1 ? "darkgrey" : "inherit"}`,
+        fontSize: "small"
+      }}
+    >
+      1
+    </button>
+    <button
+      onClick={() => handleUpdateToQuantity(card.card_block_id, 2)}
+      style={{
+        backgroundColor: `${cardBlockIdToQuantity[card.card_block_id] === 2 ? "darkgrey" : "inherit"}`,
+        fontSize: "small"
+      }}
+    >
+      2
+    </button>
+  </div>;
+
+export default QuantityUpdateButtonGroup;

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -83,6 +83,7 @@ class Deck < ApplicationRecord
       cards.affiliation,
       cards.block,
       cards.cost,
+      cards.card_block_id,
       cards.card_type,
       cards.combat_icons,
       cards.cost,


### PR DESCRIPTION
One sneaky change I want to call out also - on the deck model method where we select a bunch of fields, the card_block_id was left out, which led to a very subtle bug where the card entity looked different on the deck list view than it did on the return of the search endpoint (since the search endpoint selects every field from a `Card` and we have to do this manually on the card entities to merge in the `quantity`.)