### PR TITLE
Add simple deck stats, fix bug with card lists not displaying accurately

### DIFF
--- a/app/javascript/components/CardPanel.jsx
+++ b/app/javascript/components/CardPanel.jsx
@@ -22,6 +22,9 @@ const CardPanel = ({ cardData, includeFlavorText}) => {
         <div className="card-type-and-cost">
           { `${cardData.affiliation}. ${cardData.card_type}. Cost: ${cardData.cost}` }
         </div>
+        <div className="card-resources">
+          { `Resources: ${cardData.resources}` }
+        </div>
         <div className="card-combat-icons">
           { getIconsFromIconString(cardData.combat_icons) }
         </div>

--- a/app/javascript/components/DeckCardList.jsx
+++ b/app/javascript/components/DeckCardList.jsx
@@ -43,12 +43,14 @@ const DeckCardList = ({ cardBlockIdToQuantity, handleUpdateToQuantity, deckData 
   const fateCards = deckCards.filter((c) => c.card_type === "Fate");
   const missionCards = deckCards.filter((c) => c.card_type === "Mission");
 
+  const sumOfCards = (cards) => cards.reduce((prev, card) => prev + card.quantity, 0 );
+
   return (
     <div className="container">
       <div className="row">
         <div className="col-md-8">
           <div className="container p-2">
-            <p className="fw-bold">Objectives</p>
+            <p className="fw-bold">{`Objectives (${sumOfCards(objectiveCards)})`}</p>
             {
               objectiveCards.map((card) =>
                 <DeckCardListCardRow
@@ -71,7 +73,7 @@ const DeckCardList = ({ cardBlockIdToQuantity, handleUpdateToQuantity, deckData 
         <div className="col-md-6">
           {
             unitCards.length > 0 && <div className="container p-2">
-              <p className="fw-bold">Units</p>
+              <p className="fw-bold">{`Units (${sumOfCards(unitCards)})`}</p>
               {
                 unitCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card}/>)
               }
@@ -80,7 +82,7 @@ const DeckCardList = ({ cardBlockIdToQuantity, handleUpdateToQuantity, deckData 
 
           {
             enhancementCards.length > 0 && <div className="container p-2">
-              <p className="fw-bold">Enhancements</p>
+              <p className="fw-bold">{`Enhancements (${sumOfCards(enhancementCards)})`}</p>
               {
                 enhancementCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card}/>)
               }
@@ -90,7 +92,7 @@ const DeckCardList = ({ cardBlockIdToQuantity, handleUpdateToQuantity, deckData 
         <div className="col-md-6">
           {
             eventCards.length > 0 && <div className="container p-2">
-              <p className="fw-bold">Events</p>
+              <p className="fw-bold">{`Events (${sumOfCards(eventCards)})`}</p>
               {
                 eventCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card}/>)
               }
@@ -99,7 +101,7 @@ const DeckCardList = ({ cardBlockIdToQuantity, handleUpdateToQuantity, deckData 
 
           {
             fateCards.length > 0 && <div className="container p-2">
-              <p className="fw-bold">Fate</p>
+              <p className="fw-bold">{`Fate (${sumOfCards(fateCards)})`}</p>
               {
                 fateCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card}/>)
               }
@@ -108,7 +110,7 @@ const DeckCardList = ({ cardBlockIdToQuantity, handleUpdateToQuantity, deckData 
 
           {
             missionCards.length > 0 && <div className="container p-2">
-              <p className="fw-bold">Missions</p>
+              <p className="fw-bold">{`Missions (${sumOfCards(missionCards)})`}</p>
               {
                 missionCards.map((card) => <DeckCardListCardRow key={`dclcr-${card.id}`} card={card}/>)
               }

--- a/app/javascript/components/DeckStats.jsx
+++ b/app/javascript/components/DeckStats.jsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+const DeckStats = ({ deckData }) => {
+  const cards = deckData?.cards || [];
+  const deckStats = {
+    commandDeckCards: 0,
+    forcePips: 0,
+    resources: 0,
+    objResources: 0,
+    nonObjResources: 0,
+  }
+
+  cards.forEach((card) => {
+    if (card.card_type !== "Objective") {
+      deckStats.commandDeckCards += card.quantity;
+      deckStats.nonObjResources += (card.resources * card.quantity);
+    } else {
+      deckStats.objResources += (card.resources * card.quantity);
+    }
+
+    if (card.resources) {
+      deckStats.resources += (card.quantity * card.resources);
+    }
+
+    if (card.force) {
+      deckStats.forcePips += (card.quantity * card.force);
+    }
+  });
+
+  return (
+    <div className="container p-4">
+      <p className="fw-bold">Deck Stats</p>
+      <div>{ `Cards in command deck: ${deckStats.commandDeckCards}` }</div>
+      <div>{ `Total force pips: ${deckStats.forcePips}` }</div>
+      <div>{ `Total resources: ${deckStats.resources}` }</div>
+      <div>{ `Resources from objectives: ${deckStats.objResources}` }</div>
+      <div>{ `Resources from command deck: ${deckStats.nonObjResources}` }</div>
+    </div>
+  )
+}
+  
+
+export default DeckStats;

--- a/app/javascript/pages/Deck.jsx
+++ b/app/javascript/pages/Deck.jsx
@@ -7,6 +7,7 @@ import makeApiRequest from "../api/makeApiRequest";
 import { AuthContext } from "../components/AuthProvider";
 
 import DeckCardList from "../components/DeckCardList";
+import DeckStats from "../components/DeckStats";
 
 // List all of the cards in a deck.
 const Deck = () => {
@@ -34,6 +35,7 @@ const Deck = () => {
       <div className="row">
         <div className="col-md-6">
           <DeckCardList deckData={ deckData } />
+          <DeckStats deckData={ deckData } />
         </div>
         <div className="col-md-6">
           <div className="d-flex flex-row-reverse">

--- a/app/javascript/pages/EditDeck.jsx
+++ b/app/javascript/pages/EditDeck.jsx
@@ -8,6 +8,7 @@ import CardModal from "../components/CardModal";
 import DeckBuilder from "../components/DeckBuilder";
 import DeckInfoForm from "../components/DeckInfoForm";
 import DeckCardList from "../components/DeckCardList";
+import DeckStats from "../components/DeckStats";
 
 const EditDeck = () => {
   const [ activeTab, setActiveTab ] = useState("Build")
@@ -219,6 +220,10 @@ const EditDeck = () => {
             onSave={handleUpdateToInfo}
           />
         )
+      case "Stats":
+        return (
+          <DeckStats deckData={deckData} />
+        )
     }
   }, [
     cardList,
@@ -257,6 +262,9 @@ const EditDeck = () => {
             </li>
             <li className="nav-item">
               <a className={ activeTab == "Info" ? "nav-link active" : "nav-link"} onClick={() => setActiveTab("Info")}>Info</a>
+            </li>
+            <li className="nav-item">
+              <a className={ activeTab == "Stats" ? "nav-link active" : "nav-link"} onClick={() => setActiveTab("Stats")}>Stats</a>
             </li>
           </ul>
           { getActiveTabComponent(activeTab) }


### PR DESCRIPTION
This addresses showing some simple deck stats, and fixes a small bug for decks that had the same card name displayed across multiple objective sets not displaying properly in lists.

Definitely plan on fleshing this out more, but for now this is a good start.