### PR TITLE
Fix card search so it respects flags with any case

### DIFF
--- a/app/services/card_search.rb
+++ b/app/services/card_search.rb
@@ -47,8 +47,9 @@ class CardSearch
 
   def self.map_options_to_conditions(flag, value = nil)
     sanitized_value = Card.sanitize_search_input(value) if value
+    case_insensitive_flag = flag.downcase
 
-    case flag
+    case case_insensitive_flag
     when 'a'
       ["affiliation ILIKE ?", "%#{sanitized_value}%"]
     when 'b'


### PR DESCRIPTION
Max reported this one on Facebook.  With this change, `k:civilian` will be treated the same as `K:civilian` - the flags will be respected regardless of case.

Prior to this - the latter would just search all card names containing `K` or `k`... not ideal.