### PR TITLE
Hide the card image for the card modal when editing decks on mobile

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -80,3 +80,12 @@
 .normal-font {
   font-family: var(--bs-body-font-family);
 }
+
+.hide-for-sm {
+  display: none;
+}
+@media (min-width: 768px) {
+  .hide-for-sm {
+    display: block;
+  }
+}

--- a/app/javascript/components/CardModal.jsx
+++ b/app/javascript/components/CardModal.jsx
@@ -27,7 +27,7 @@ export default function CardModal({ cardId, onClose, onCardNameClick, onQuantity
                 <CardPanel includeFlavorText cardData={cardData} />
               </div>
               <div className="col-md-6">
-                { cardData.set && <img src={ getCardImageUrl(cardData) }></img> }
+                { cardData.set && <img className="hide-for-sm" src={ getCardImageUrl(cardData) }></img> }
               </div>
             </div>
             <div className="row border-top py-2">


### PR DESCRIPTION
Its very annoying to edit decks on mobile right now.  In particular, the modal that comes up when you click on a card is way too big, and it's positioning/lack of scroll makes it impossible to work with.

This small change just hides the card image when we're on a small screen using a media query.