### PR TITLE
Add delete decks functionality, redirect if requesting a route with a nonexistent deck

### DIFF
--- a/app/controllers/api/decks_controller.rb
+++ b/app/controllers/api/decks_controller.rb
@@ -85,6 +85,23 @@ class Api::DecksController < ApplicationController
     end
   end
 
+  # DELETE api/decks/:id
+  # Must be authenticated, which means @current_user should be set prior to this
+  # Returns a 204 status with no content on a successful deletion
+
+  def destroy
+    # Note that this will raise if the deck isn't found, which will return a 404
+    found_deck = Deck.find(params[:id])
+
+    raise 'unauthorized' if found_deck.user_id != @current_user.id
+
+    found_deck.destroy!
+
+    respond_to do |format|
+      format.json { render json: { message: 'success' }, status: :ok }
+    end
+  end
+
   # GET api/decks/byFaction/mostRecent
   # Get the last deck created from each faction
   def most_recent_decks_by_faction

--- a/app/javascript/pages/Deck.jsx
+++ b/app/javascript/pages/Deck.jsx
@@ -1,5 +1,5 @@
-import React, { useContext, useCallback, useEffect, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import React, { useContext, useEffect, useState } from "react";
+import { Link, useParams, useNavigate } from "react-router-dom";
 import _ from "lodash";
 import moment from "moment";
 
@@ -12,13 +12,24 @@ import DeckStats from "../components/DeckStats";
 // List all of the cards in a deck.
 const Deck = () => {
   const [ deckData, setDeckData ] = useState({})
+  const [ error, setError ] = useState(null)
   const params = useParams();
   const { user } = useContext(AuthContext);
+  const navigate = useNavigate();
 
   useEffect(() => {
     async function getDeckById() {
-      const _set = await makeApiRequest(`/api/decks/${params.id}`);
-      setDeckData(_set);
+      try {
+        const set = await makeApiRequest(`/api/decks/${params.id}`);
+
+        if (set.error) {
+          throw new Error('API request failed');
+        }
+
+        setDeckData(set);
+      } catch (err) {
+        navigate('/decklists'); // Redirect because either there's a problem with this deck, or it doesn't exist
+      }
     };
 
     getDeckById();
@@ -26,8 +37,24 @@ const Deck = () => {
 
   const isUserDeck = (deckData, user) => deckData?.user?.id === user?.id;
 
+  const deleteDeck = async () => {
+    const res = await makeApiRequest(`/api/decks/${params.id}`, { method: 'DELETE' });
+
+    if (res.message == 'success') {
+      navigate('/myDecks');
+    } else {
+      setError('There was a problem deleting this deck!')
+    }
+  }
+
   return (
     <div className="container">
+      { error &&
+        <div className="alert alert-danger alert-dismissible" role="alert">
+          <div>{ error }</div>
+          <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+      } 
       <div className="row bg-primary pt-4 mb-2">
         <h2 className="text-light text-center star-wars-font">{ deckData.name }</h2>
         <p className="text-light text-end">{ `Last updated: ${deckData && moment(deckData.updated_at).fromNow()}` }</p>
@@ -40,6 +67,7 @@ const Deck = () => {
         <div className="col-md-6">
           <div className="d-flex flex-row-reverse">
             { isUserDeck(deckData, user) && <Link to={`/editDeck/${deckData.id}`}><button type="button" className="btn btn-primary mx-1">Edit</button></Link> }
+            { isUserDeck(deckData, user) && <button type="button" className="btn btn-danger mx-1" onClick={deleteDeck}>Delete</button> }
             {/* TODO <Link><button type="button" className="btn btn-secondary mx-1">Clone</button></Link> */}
           </div>
           <div className="row">

--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -2,7 +2,7 @@ class Deck < ApplicationRecord
   belongs_to :user
   belongs_to :affiliation
 
-  has_many :deck_card_blocks
+  has_many :deck_card_blocks, dependent: :destroy
   has_many :card_blocks, through: :deck_card_blocks
   has_many :cards, through: :card_blocks
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resources :cards, only: [:show]
     resources :card_blocks, only: [:show]
     resources :card_sets, only: [:index, :show]
-    resources :decks, only: [:show, :create, :update, :index]
+    resources :decks, only: [:show, :create, :update, :index, :destroy]
     resources :search, only: [:create]
     resources :users, except: [:index]  # Avoid route showing all users
 


### PR DESCRIPTION
- Added a route to delete decks
- Added some basic error handling if this fails
- Redirect to the decklist if you ask for a deck ID that doesn't exist
- Redirect to mydecks if the deletion succeeds

Also tested to make sure deletion doesn't appear when you view a deck that's not yours.