### PR TITLE
Create script to map octgn images to a new format using block and block number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ yarn-error.log
 .env
 
 /config/credentials
+
+# These are used by a script to generate the card images for CDN, but there are too many to commit
+/cards
+/octgn_cards

--- a/scripts/copy_images_with_new_filenames.rb
+++ b/scripts/copy_images_with_new_filenames.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+# Load Rails so we can use some helpful methods
+require_relative '../config/environment.rb'
+
+def set_xml_filenames
+  Dir.glob('./db/cardXml/**/*set.xml')
+end
+
+set_xml_filenames.each do |filename|
+  xml = File.open(filename)
+  set_data = Hash.from_xml(xml)["set"]
+
+  card_list = set_data["cards"]["card"]
+  card_list.each do |card|
+    property_arr = card["property"]
+    block = property_arr.find { |prop| prop["name"] == "Block" }["value"].to_i
+    block_number = property_arr.find { |prop| prop["name"] == "Block Number" }["value"].to_i
+
+    ROOT_DIR = File.expand_path(".")
+    current_path = "#{ROOT_DIR}/octgn_cards/SWLCG-images/Sets/#{set_data["id"]}/Cards/#{card["id"]}.jpg"
+    updated_path = "#{ROOT_DIR}/cards/#{block}-#{block_number}.jpg"
+
+    begin
+      puts "Copying file:"
+      puts "#{current_path} --> #{updated_path}"
+      puts "\n"
+
+      FileUtils.cp(current_path, updated_path)
+
+      puts "Copy succeeded!"
+    rescue => e
+      puts "Error copying file: #{current_path}"
+      puts "Message: #{e.message}"
+
+      next
+    end
+  end
+end


### PR DESCRIPTION
This works fine, it created an extra card with 0-0.jpg, but otherwise seems ok.  The plan now is to take the output of the copy, and scp those to a digital ocean bucket, which will hopefully be fronted by a CDN.

This, on its own, doesn't make any client-facing changes, we'll need another commit for that once I can verify these are being served correctly.

May as well commit this since it could come in handy in case I ever need to recover these.