### PR TITLE
Update quantity calculation on decks to consider both the card name and the card text

### DIFF
--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -77,7 +77,7 @@ class Deck < ApplicationRecord
     # First, query for all of the cards in the deck, using distinct to cut out the extras, and return a list of hashes
     
     distinct_cards = cards.select(
-      "distinct on(cards.name)
+      "distinct on(cards.name, cards.text)
       cards.id,
       cards.name,
       cards.affiliation,
@@ -100,7 +100,7 @@ class Deck < ApplicationRecord
     # Compute a mapping of card names to quantites
     cards_with_quantities = Card.joins(card_block: :deck_card_blocks)
                                 .select('cards.name', 'SUM(deck_card_blocks.quantity) as quantity')
-                                .where({ 'deck_card_blocks.deck_id' => self.id }).group('cards.name')
+                                .where({ 'deck_card_blocks.deck_id' => self.id }).group('cards.name', 'cards.text')
 
     card_name_to_quantity = {}.tap { |h| cards_with_quantities.map { |c| h[c.name] = c.quantity }}
 


### PR DESCRIPTION
This will close #90 .

Ohhhkay.  This one at first glance is a very small change, but I want to document it thoroughly because it's not a perfect solution - I think it's _better_ but it has tradeoffs.

Here are two decks I created before the change:

Deck.find(23):
![Screenshot 2025-05-16 at 4 25 18 PM](https://github.com/user-attachments/assets/c9287aa3-e518-4d49-b7a1-89792c59672d)

Deck.find(24):
![Screenshot 2025-05-16 at 4 21 55 PM](https://github.com/user-attachments/assets/35255506-5164-44d6-9f77-b3664da3e6c8)

So, 23 is a problem, because those are three different instances of Yoda!  So we've now lost some data that we're interested in showing to the client when we're rendering the card information.

Initially with this change, we do now see the three different Yodas - but there's another problem:

Deck.find(23) - with this change - 
![Screenshot 2025-05-16 at 4 22 33 PM](https://github.com/user-attachments/assets/0afeac4a-082f-4073-94ba-1fd6e3ff76c0)

Annoyingly, there are now doubles of the Dagobah Training Grounds!

This seemed to challenge an assumption I was making - that although there are many cards in the card pool with the same name, effectively if the card has the same name AND the same text, it _should_ just be another copy of the same card.

I looked into this, and yep, sure enough the text in the database differs by one character of whitespace.  

Correcting the problem in the database, renders it all correctly:
![Screenshot 2025-05-16 at 5 19 34 PM](https://github.com/user-attachments/assets/aa165d23-ec2f-408c-afde-5becf0785c46)

As an aside, these changes (correctly) do not alter what a deck like the one with ID 24 looks like.  The Twist of Fates and other multiples correctly collapse.

So. as a follow up to this, I'll need to look at places where this phenomenon occurs - this was definitely a consequence of migrating data from OCTGN XML files to SQL.
