### PR TITLE
Make register new user flow actually show errors when they happen

### DIFF
--- a/app/javascript/pages/RegisterNewUser.jsx
+++ b/app/javascript/pages/RegisterNewUser.jsx
@@ -58,7 +58,7 @@ const SuccessMessage = () => {
 };
 
 const RegisterNewUser = () => {
-  const [error, setError] = useState(false);
+  const [errors, setErrors] = useState(false);
   const [userCreated, setUserCreated] = useState(false);
   const [createUserPayload, setCreateUserPayload] = useState({});
 
@@ -87,23 +87,23 @@ const RegisterNewUser = () => {
         body: finalPayload,
       });
 
-      if (response.error) {
-        setError(response.error)
+      if (response.errors?.length > 0) {
+        setErrors(response.errors)
       } else {
+        setErrors(false)
         setUserCreated(true)
       }
     } catch (err) {
-      setError(err)
+      setErrors(err)
     }
   }, [createUserPayload])
 
   return (
     <div className="container">
       {
-        error && (
+        errors && (
           <div className="alert alert-danger alert-dismissible" role="alert">
-            <div>{ error }</div>
-            <button type="button" className="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <div>{ `The submission encountered the following errors:  ${errors.join(", ")}` }</div>
           </div>
         )
       }


### PR DESCRIPTION
I got a bug report from Palpa that register new user doesn't properly show in the UI when there are errors, and once I sorted out with him what was going on with his account (he was trying to register a second account with the same username) it was pretty easy to find the bug in the front end code that caused this.  The UI will now actually show errors when they happen, hopefully leading to less confusion.  

<img width="793" height="514" alt="Screenshot 2025-10-07 at 3 37 21 PM" src="https://github.com/user-attachments/assets/e96b65cf-6adf-4827-98a9-14b565bbd62e" />
